### PR TITLE
allow transform to remove rows for loading

### DIFF
--- a/lib/dataduck/table.rb
+++ b/lib/dataduck/table.rb
@@ -94,7 +94,8 @@ module DataDuck
         self.extract!(destination, options)
         if self.data.length > 0
           self.transform!
-          self.load!(destination)
+          self.data.compact!
+          self.load!(destination) if self.data.length > 0
           data_processed = true
         end
 


### PR DESCRIPTION
If you have a transform that nils outs rows so that they don't get transferred, this will compact the data so that the load method doesn't eventually break on parsing nils.

Example of my table:

```ruby
  # typical source, output, batch_size and extract_by_column snipped

  transform :only_usable_rows

  def only_usable_rows(row)
    return nil unless some_check_that_may_include_or_exclude_this(row)
    row
  end
```