### PR TITLE
Fix Exception usage

### DIFF
--- a/lib/dataduck.rb
+++ b/lib/dataduck.rb
@@ -31,7 +31,7 @@ module DataDuck
   detect_project_root = Dir.getwd
   while true
     if detect_project_root == ""
-      raise Exception.new("Could not find a Gemfile in the current working directory or any parent directories. Are you sure you're running this from the right place?")
+      raise "Could not find a Gemfile in the current working directory or any parent directories. Are you sure you're running this from the right place?"
     end
 
     if File.exist?(detect_project_root + '/Gemfile')

--- a/lib/dataduck/commands.rb
+++ b/lib/dataduck/commands.rb
@@ -50,7 +50,7 @@ module DataDuck
 
       begin
         DataDuck::Commands.public_send(command, *args[1..-1])
-      rescue Exception => err
+      rescue => err
         DataDuck::Logs.error(err)
       end
     end
@@ -112,7 +112,7 @@ module DataDuck
           require DataDuck.project_root + "/src/tables/#{ table_name }.rb"
           table_class = Object.const_get(table_name_camelized)
           if !(table_class <= DataDuck::Table)
-            raise Exception.new("Table class #{ table_name_camelized } must inherit from DataDuck::Table")
+            raise "Table class #{ table_name_camelized } must inherit from DataDuck::Table"
           end
           table = table_class.new
           tables << table
@@ -136,7 +136,7 @@ module DataDuck
       require DataDuck.project_root + "/src/tables/#{ table_name }.rb"
       table_class = Object.const_get(table_name_camelized)
       if !(table_class <= DataDuck::Table)
-        raise Exception.new("Table class #{ table_name_camelized } must inherit from DataDuck::Table")
+        raise "Table class #{ table_name_camelized } must inherit from DataDuck::Table"
       end
       table = table_class.new
       table.recreate!(DataDuck::Destination.only_destination)
@@ -158,7 +158,7 @@ module DataDuck
         require DataDuck.project_root + "/src/tables/#{ table_name }.rb"
         table_class = Object.const_get(table_name_camelized)
         if !(table_class <= DataDuck::Table)
-          raise Exception.new("Table class #{ table_name_camelized } must inherit from DataDuck::Table")
+          raise "Table class #{ table_name_camelized } must inherit from DataDuck::Table"
         end
 
         table = table_class.new

--- a/lib/dataduck/database.rb
+++ b/lib/dataduck/database.rb
@@ -7,15 +7,15 @@ module DataDuck
     end
 
     def connection
-      raise Exception.new("Must implement connection in subclass.")
+      raise "Must implement connection in subclass."
     end
 
     def query(sql)
-      raise Exception.new("Must implement query in subclass.")
+      raise "Must implement query in subclass."
     end
 
     def table_names
-      raise Exception.new("Must implement query in subclass.")
+      raise "Must implement query in subclass."
     end
 
     protected

--- a/lib/dataduck/destination.rb
+++ b/lib/dataduck/destination.rb
@@ -20,18 +20,18 @@ module DataDuck
 
     def self.destination_config(name)
       if DataDuck.config['destinations'].nil? || DataDuck.config['destinations'][name.to_s].nil?
-        raise Exception.new("Could not find destination #{ name } in destinations configs.")
+        raise "Could not find destination #{ name } in destinations configs."
       end
 
       DataDuck.config['destinations'][name.to_s]
     end
 
     def load_table!(table)
-      raise Exception.new("Must implement load_table! in subclass")
+      raise "Must implement load_table! in subclass"
     end
 
     def recreate_table!(table)
-      raise Exception.new("Must implement load_table! in subclass")
+      raise "Must implement recreate_table! in subclass"
     end
 
     def postprocess!(table)
@@ -46,7 +46,7 @@ module DataDuck
       elsif allow_nil
         return nil
       else
-        raise Exception.new("Could not find destination #{ name } in destination configs.")
+        raise "Could not find destination #{ name } in destination configs."
       end
     end
 

--- a/lib/dataduck/etl.rb
+++ b/lib/dataduck/etl.rb
@@ -51,7 +51,7 @@ module DataDuck
         Logs.info("Processing table '#{ table.name }'...")
         begin
           table.etl!(destinations_to_use)
-        rescue Exception => err
+        rescue => err
           Logs.error("Error while processing table '#{ table.name }': #{ err.to_s }\n#{ err.backtrace.join("\n") }")
           errored_tables << table
         end

--- a/lib/dataduck/redshift_destination.rb
+++ b/lib/dataduck/redshift_destination.rb
@@ -203,7 +203,7 @@ module DataDuck
       Logs.debug("SQL executing on #{ self.name }:\n  " + sql)
       begin
         self.connection[sql].map { |elem| elem }
-      rescue Exception => err
+      rescue => err
         if err.to_s.include?("Check 'stl_load_errors' system table for details")
           self.raise_stl_load_error!
         else
@@ -266,7 +266,7 @@ module DataDuck
       DataDuck::Logs.info "Recreating table #{ table.name }..."
 
       if !self.table_names.include?(table.name)
-        raise Exception.new("Table #{ table.name } doesn't exist on the Redshift database, so it can't be recreated. Did you want to use `dataduck create #{ table.name }` instead?")
+        raise "Table #{ table.name } doesn't exist on the Redshift database, so it can't be recreated. Did you want to use `dataduck create #{ table.name }` instead?"
       end
 
       recreating_temp_name = "zz_dataduck_recreating_#{ table.name }"

--- a/lib/dataduck/s3_object.rb
+++ b/lib/dataduck/s3_object.rb
@@ -50,7 +50,7 @@ module DataDuck
             })
         begin
           response = s3.put_object(put_hash)
-        rescue Exception => e
+        rescue => e
           if attempts == S3Object.max_retries
             throw e
           end

--- a/lib/dataduck/source.rb
+++ b/lib/dataduck/source.rb
@@ -22,7 +22,7 @@ module DataDuck
 
     def self.source_config(name)
       if DataDuck.config['sources'].nil? || DataDuck.config['sources'][name.to_s].nil?
-        raise Exception.new("Could not find source #{ name } in source configs.")
+        raise "Could not find source #{ name } in source configs."
       end
 
       DataDuck.config['sources'][name.to_s]
@@ -36,7 +36,7 @@ module DataDuck
       elsif allow_nil
         return nil
       else
-        raise Exception.new("Could not find source #{ name } in source configs.")
+        raise "Could not find source #{ name } in source configs."
       end
     end
 

--- a/lib/dataduck/table.rb
+++ b/lib/dataduck/table.rb
@@ -57,8 +57,8 @@ module DataDuck
 
     def check_table_valid!
       if !self.batch_size.nil?
-        raise Exception.new("Table #{ self.name }'s batch_size must be > 0") unless self.batch_size > 0
-        raise Exception.new("Table #{ self.name } has batch_size defined but no extract_by_column") if self.extract_by_column.nil?
+        raise "Table #{ self.name }'s batch_size must be > 0" unless self.batch_size > 0
+        raise "Table #{ self.name } has batch_size defined but no extract_by_column" if self.extract_by_column.nil?
       end
     end
 

--- a/lib/integrations/optimizely/optimizely_integration.rb
+++ b/lib/integrations/optimizely/optimizely_integration.rb
@@ -43,7 +43,7 @@ module DataDuck
           experiment_variations = []
           begin
             experiment_variations = fetch_data(endpoint)
-          rescue Exception => err
+          rescue => err
             broken_experiments << experiment
           end
           experiment_variations.each do |exp_var|
@@ -69,7 +69,7 @@ module DataDuck
 
         response = Typhoeus.get("https://www.optimizelyapis.com/experiment/v1/#{ api_endpoint }", headers: {'Token' => optimizely_api_token})
         if response.response_code != 200
-          raise Exception.new("Optimizely API for #{ api_endpoint } returned error #{ response.response_code} #{ response.body }")
+          raise "Optimizely API for #{ api_endpoint } returned error #{ response.response_code} #{ response.body }"
         end
 
         rows = Oj.load(response.body)

--- a/lib/integrations/semrush/organic_results.rb
+++ b/lib/integrations/semrush/organic_results.rb
@@ -4,7 +4,7 @@ require 'uri'
 
 module DataDuck
   module SEMRush
-    class OrganicResultsAPIError < Exception; end
+    class OrganicResultsAPIError < StandardError; end
 
     class OrganicResults < DataDuck::IntegrationTable
       def display_limit
@@ -16,7 +16,7 @@ module DataDuck
       end
 
       def phrases
-        raise Exception("Must implement phrases method to be an array of the phrases you want.")
+        raise "Must implement phrases method to be an array of the phrases you want."
       end
 
       def prefix


### PR DESCRIPTION
In ruby `Exception` is the root class of the hierarchy, it should not be caught most of the time, as that prevents terminating the program with kill or Ctrl-C. `raise` without a type specified catches `StandardError`, that's what is needed most of the time.

On the similar reason `Exception` should not be thrown directly, `raise` with a string parameter creates `RuntimeError` with it.

You can also check the discussion at http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby